### PR TITLE
Use dhclient to remove previously assigned ip

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ address.
 ## Install 
 
 ```
-sudo apt install macchanger net-tools
+sudo apt install macchanger net-tools isc-dhcp-client
 cd /path/to/macacetamol
 sudo cp changemac.service /etc/systemd/system/
 sudo sed -i -E "s|ABS_PATH|$(pwd)/change_mac|g" /etc/systemd/system/changemac.service

--- a/change_mac
+++ b/change_mac
@@ -1,4 +1,6 @@
 #!/bin/env bash
 sudo ifconfig eth0 down
+sudo dhclient -r eth0
 sudo macchanger -r eth0
 sudo ifconfig eth0 up
+sudo dhclient eth0


### PR DESCRIPTION
Sometimes in some devices, changing the mac only does not change ip address, so forcefully remove the previously assigned address and try to generate new after getting new mac address.